### PR TITLE
feat(web): show accessible telegram channels

### DIFF
--- a/apps/web/src/routes/telegram.tsx
+++ b/apps/web/src/routes/telegram.tsx
@@ -2,6 +2,8 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
 
 type Status = { configured: boolean; loggedIn: boolean };
+type Channel = { id: number; title: string };
+type ChannelGroup = { group: string; channels: Channel[] };
 
 export const Route = createFileRoute("/telegram")({
   component: RouteComponent,
@@ -18,6 +20,9 @@ function RouteComponent() {
   const [phone, setPhone] = useState("");
   const [code, setCode] = useState("");
   const [password, setPassword] = useState("");
+  const [channelGroups, setChannelGroups] = useState<ChannelGroup[]>([]);
+  const [channelsLoading, setChannelsLoading] = useState(false);
+  const [channelsError, setChannelsError] = useState<string | null>(null);
 
   async function fetchStatus() {
     setError(null);
@@ -34,6 +39,25 @@ function RouteComponent() {
   useEffect(() => {
     void fetchStatus();
   }, []);
+
+  useEffect(() => {
+    if (status.loggedIn) void fetchChannels();
+  }, [status.loggedIn]);
+
+  async function fetchChannels() {
+    setChannelsError(null);
+    setChannelsLoading(true);
+    try {
+      const res = await fetch(`${apiBase}/api/telegram/channels`);
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const data = (await res.json()) as { groups: ChannelGroup[] };
+      setChannelGroups(data.groups);
+    } catch (e: any) {
+      setChannelsError(e?.message || "Error");
+    } finally {
+      setChannelsLoading(false);
+    }
+  }
 
   async function startLogin(e: React.FormEvent) {
     e.preventDefault();
@@ -169,6 +193,26 @@ function RouteComponent() {
       {step === "done" && (
         <div className="mt-4">
           <div className="text-green-400">Sesión configurada correctamente.</div>
+        </div>
+      )}
+
+      {status.loggedIn && (
+        <div className="mt-6">
+          <h2 className="text-lg font-semibold mb-2">Canales disponibles</h2>
+          {channelsError && (
+            <div className="text-red-400 text-sm mb-2">{channelsError}</div>
+          )}
+          {channelsLoading && <div className="text-sm">Cargando…</div>}
+          {channelGroups.map((g) => (
+            <div key={g.group} className="mb-4">
+              <h3 className="font-medium">{g.group}</h3>
+              <ul className="list-disc ml-5">
+                {g.channels.map((ch) => (
+                  <li key={ch.id}>{ch.title}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/services/telegram/TelegramService.ts
+++ b/src/services/telegram/TelegramService.ts
@@ -80,10 +80,12 @@ export class TelegramService {
     this.client.addEventHandler(async (update) => {
       try {
         if (!('message' in update) || !update.message) return;
-        const msg = (update as any).message as Api.Message;
+        const msg = update.message as Api.Message;
         if (!(msg instanceof Api.Message)) return;
-        const peer = msg.peerId as any;
-        const channelId = 'channelId' in peer ? Number(peer.channelId?.toString()) : undefined;
+        const peer = msg.peerId as { channelId?: bigint };
+        const channelId = peer.channelId
+          ? Number(peer.channelId.toString())
+          : undefined;
         if (allow.size > 0 && (!channelId || !allow.has(channelId))) return;
 
         const text = msg.message || '';
@@ -110,6 +112,41 @@ export class TelegramService {
     const session = (this.client.session as StringSession).save();
     const encrypted = encrypt(session, env.TELEGRAM_ENC_SECRET);
     await TelegramSessionRepo.upsert(encrypted, 1);
+  }
+
+  async listChannels(): Promise<
+    { group: string; channels: { id: number; title: string }[] }[]
+  > {
+    if (!this.client) throw new Error('Telegram client not connected');
+
+    const dialogs = await this.client.getDialogs({});
+
+    const filtersObj = await this.client.invoke(
+      new Api.messages.GetDialogFilters()
+    );
+    const filterMap = new Map<number, string>();
+    const filters = (
+      filtersObj as { filters?: { id: number; title: string }[] }
+    ).filters;
+    if (filters) {
+      for (const f of filters) filterMap.set(f.id, f.title);
+    }
+
+    const groups = new Map<string, { id: number; title: string }[]>();
+
+    for (const d of dialogs) {
+      if (!(d.isChannel || d.isGroup)) continue;
+      const folderId = (d.dialog as { folderId?: number })?.folderId;
+      const groupName = folderId
+        ? filterMap.get(folderId) ?? `Grupo ${folderId}`
+        : 'Sin grupo';
+      if (!groups.has(groupName)) groups.set(groupName, []);
+      groups
+        .get(groupName)!
+        .push({ id: Number(d.id), title: d.name });
+    }
+
+    return Array.from(groups, ([group, channels]) => ({ group, channels }));
   }
 }
 

--- a/src/web/routes/telegram.ts
+++ b/src/web/routes/telegram.ts
@@ -66,6 +66,16 @@ telegramRouter.get('/status', async (_req, res, next) => {
   }
 });
 
+// GET /api/telegram/channels -> list of accessible channels grouped
+telegramRouter.get('/channels', async (_req, res, next) => {
+  try {
+    const groups = await telegramService.listChannels();
+    res.json({ groups });
+  } catch (err) {
+    next(err);
+  }
+});
+
 // POST /api/telegram/login/start { phone: string }
 telegramRouter.post('/login/start', async (req, res, next) => {
   try {


### PR DESCRIPTION
## Summary
- expose `/api/telegram/channels` to list available Telegram channels grouped by folder
- display accessible channels on the Telegram settings page

## Testing
- `bun run lint` *(fails: Unexpected any, Missing return type, etc.)*
- `bun run test`
- `cd apps/web && bun run check-types` *(fails: TS2339: Property 'message' does not exist on type '{}')*

------
https://chatgpt.com/codex/tasks/task_e_68b2c05967e08330a0d9268ec81c876e

## Summary by Sourcery

Expose a new endpoint and service method to list Telegram channels grouped by folder, and integrate UI support to fetch and display these channels on the Telegram settings page.

New Features:
- Add listChannels method in TelegramService and expose /api/telegram/channels API endpoint to return channels grouped by folder
- Display accessible Telegram channels on the web UI settings page with loading and error states

Enhancements:
- Refine TelegramService update handler with stricter type checks for peer and channelId extraction